### PR TITLE
Refactor20180907

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,17 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.tokyoc.line_client">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name=".MessageApplication"
         android:allowBackup="true"
-        android:usesCleartextTraffic="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <activity android:name=".SigninActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -20,26 +20,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".MessageActivity"
             android:windowSoftInputMode="adjustResize" />
+        <activity android:name=".MemberActivity" />
+        <activity android:name=".GroupActivity" />
+        <activity android:name=".SignupActivity" />
+        <activity android:name=".AddFriendActivity" />
+        <activity android:name=".MakeGroupActivity" />
 
-        <activity
-            android:name=".MemberActivity" />
-
-        <activity
-            android:name=".GroupActivity" />
-
-        <activity
-            android:name=".SignupActivity" />
-
-        <activity
-            android:name=".AddFriendActivity" />
-
-        <activity
-            android:name=".MakeGroupActivity" />
-
+        <service android:name=".PollingService" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/tokyoc/line_client/Client.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Client.kt
@@ -1,13 +1,51 @@
 package com.tokyoc.line_client
 
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import okhttp3.ResponseBody
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.*
 import rx.Observable
+import java.util.concurrent.TimeUnit
 
 interface Client {
+    companion object {
+        public val gson : Gson =GsonBuilder()
+                .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+                .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
+                .setLenient()
+                .create()
+
+        fun build(token: String): Client {
+            val authenticatedClient = OkHttpClient().newBuilder()
+                    .readTimeout(0, TimeUnit.SECONDS)
+                    .addInterceptor(Interceptor { chain ->
+                        chain.proceed(
+                                chain.request()
+                                        .newBuilder()
+                                        .header("Authorization", "Bearer $token")
+                                        .build())
+                    })
+                    .build()
+            val retrofit = Retrofit.Builder()
+                    .client(authenticatedClient)
+                    .baseUrl(BuildConfig.BACKEND_BASEURL)
+                    .addConverterFactory(GsonConverterFactory.create(gson))
+                    .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
+                    .build()
+
+            return retrofit.create(Client::class.java)
+        }
+    }
+
     @GET("/messages/{channel}")
     @Streaming
-    fun getMessages(@Path("channel") channel: Int, @Query("since_id") since_id : Int = 0): Observable<ResponseBody>
+    fun getMessages(@Path("channel") channel: Int, @Query("since_id") since_id: Int = 0): Observable<ResponseBody>
 
     @Headers("Content-Type: application/json")
     @POST("/messages/{channel}") //serverの構造依存

--- a/app/src/main/java/com/tokyoc/line_client/InviteActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/InviteActivity.kt
@@ -40,29 +40,7 @@ class InviteActivity : AppCompatActivity() {
         val groupId: Int = intent.getIntExtra("groupId", 0)
 
         val group = realm.where<Group>().equalTo("groupId", groupId).findFirst()
-
-        val gson = GsonBuilder()
-                .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-                .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
-                .setLenient()
-                .create()
-        val authenticatedClient = OkHttpClient().newBuilder()
-                .readTimeout(0, TimeUnit.SECONDS)
-                .addInterceptor(Interceptor { chain ->
-                    chain.proceed(
-                            chain.request()
-                                    .newBuilder()
-                                    .header("Authorization", "Bearer $token")
-                                    .build())
-                })
-                .build()
-        val retrofit = Retrofit.Builder()
-                .client(authenticatedClient)
-                .baseUrl(BuildConfig.BACKEND_BASEURL)
-                .addConverterFactory(GsonConverterFactory.create(gson))
-                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-                .build()
-        val client = retrofit.create(Client::class.java)
+        val client = Client.build(token)
 
         //Realmを利用するために必要なもの
         realm = Realm.getDefaultInstance()

--- a/app/src/main/java/com/tokyoc/line_client/MakeGroupActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MakeGroupActivity.kt
@@ -37,30 +37,7 @@ class MakeGroupActivity: RxAppCompatActivity() {
 
         val groupNameEditText = findViewById<EditText>(R.id.group_name)
 
-        //通信の準備
-        val gson = GsonBuilder()
-                .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
-                .setLenient()
-                .create()
-        val authenticatedClient = OkHttpClient().newBuilder()
-                .readTimeout(0, TimeUnit.SECONDS)
-                .addInterceptor(Interceptor { chain ->
-                    chain.proceed(
-                            chain.request()
-                                    .newBuilder()
-                                    .header("Authorization", "Bearer $token")
-                                    .build())
-                })
-                .build()
-        val retrofit = Retrofit.Builder()
-                .client(authenticatedClient)
-                .baseUrl(BuildConfig.BACKEND_BASEURL)
-                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-                .addConverterFactory(GsonConverterFactory.create(gson))
-                .build()
-
-        val client = retrofit.create(Client::class.java)
-
+        val client = Client.build(token)
 
         //グループ作成ボタンを押した時の処理
         findViewById<Button>(R.id.make_group).setOnClickListener {

--- a/app/src/main/java/com/tokyoc/line_client/MessageActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MessageActivity.kt
@@ -60,28 +60,8 @@ class MessageActivity : RxAppCompatActivity() {
         listView.setSelection(listAdapter.messages0.size)
 
         //通信に使うものたちの定義
-        val gson = GsonBuilder()
-                .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
-                .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
-                .setLenient()
-                .create()
-        val authenticatedClient = OkHttpClient().newBuilder()
-                .readTimeout(0, TimeUnit.SECONDS)
-                .addInterceptor(Interceptor { chain ->
-                    chain.proceed(
-                            chain.request()
-                                    .newBuilder()
-                                    .header("Authorization", "Bearer $token")
-                                    .build())
-                })
-                .build()
-        val retrofit = Retrofit.Builder()
-                .client(authenticatedClient)
-                .baseUrl(BuildConfig.BACKEND_BASEURL)
-                .addConverterFactory(GsonConverterFactory.create(gson))
-                .addCallAdapterFactory(RxJavaCallAdapterFactory.create())
-                .build()
-        val client = retrofit.create(Client::class.java)
+        val client = Client.build(token)
+
         var since_id = realm.where<Message>().max("id")
         if (since_id == null) {
             since_id = 0
@@ -98,7 +78,7 @@ class MessageActivity : RxAppCompatActivity() {
                         rx.Observable.create(rx.Observable.OnSubscribe<Message> {
                             try {
                                 while (!source.exhausted()) {
-                                    it.onNext(gson.fromJson<Message>(source.readUtf8Line(), Message::class.java))
+                                    it.onNext(Client.gson.fromJson<Message>(source.readUtf8Line(), Message::class.java))
                                 }
 
                                 it.onCompleted()
@@ -149,7 +129,7 @@ class MessageActivity : RxAppCompatActivity() {
             messageEditText.setText("", TextView.BufferType.NORMAL)
 
             //ここから通信部分！
-            Log.d("COMM", gson.toJson(message))
+            Log.d("COMM", Client.gson.toJson(message))
 
             client.sendMessage(groupId, message) //channel番号はgetExtraから本来は読み込む
                     .subscribeOn(Schedulers.io())

--- a/app/src/main/java/com/tokyoc/line_client/PollingService.kt
+++ b/app/src/main/java/com/tokyoc/line_client/PollingService.kt
@@ -1,0 +1,28 @@
+package com.tokyoc.line_client
+
+import android.app.IntentService
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava.RxJavaCallAdapterFactory
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+class PollingService : IntentService("polling_service") {
+    override fun onHandleIntent(intent: Intent) {
+        val token = intent.getStringExtra("token")
+        val client = Client.build(token)
+
+        while (true) {
+            client.getStatus()
+
+            Thread.sleep(1000)
+        }
+    }
+}

--- a/app/src/main/java/com/tokyoc/line_client/SigninActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/SigninActivity.kt
@@ -23,17 +23,7 @@ class SigninActivity : AppCompatActivity() {
         val passwordEditText: EditText = findViewById<EditText>(R.id.password_edit_text)
 
         findViewById<Button>(R.id.signin_button).setOnClickListener {
-            val email = emailEditText.text.toString()
-            val password = passwordEditText.text.toString()
-
-            //空白でなければ一般のサインイン処理
-            if (email.isEmpty() && password.isEmpty()) {
-                val intent = Intent(this, MemberActivity::class.java)
-                startActivity(intent)
-                return@setOnClickListener
-            }
-
-            signIn(email, password)
+            signIn(emailEditText.text.toString(), passwordEditText.text.toString())
         }
 
         findViewById<TextView>(R.id.to_signup).setOnClickListener {

--- a/app/src/main/java/com/tokyoc/line_client/SigninActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/SigninActivity.kt
@@ -54,6 +54,10 @@ class SigninActivity : AppCompatActivity() {
                     val intent = Intent(this, GroupActivity::class.java)
                     intent.putExtra("token", token)
                     startActivity(intent)
+
+                    val service = Intent(this, PollingService::class.java)
+                    service.putExtra("token", token)
+                    startService(service)
                 }
             }
         }


### PR DESCRIPTION
* バックグラウンドサービス実装の準備
* `gson` , `authenticated_client` , `client` 生成の一連の処理を `Client.build` に集約
* 認証スキップの廃止 