### PR TITLE
restructured API

### DIFF
--- a/app/src/main/java/com/tokyoc/line_client/Client.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Client.kt
@@ -43,17 +43,21 @@ interface Client {
         }
     }
 
-    @GET("/messages/{channel}")
+    @GET("/messages")
     @Streaming
-    fun getMessages(@Path("channel") channel: Int, @Query("since_id") since_id: Int = 0): Observable<ResponseBody>
+    fun getMessages(@Query("channel") channel: Int, @Query("since_id") since_id: Int = 0): Observable<ResponseBody>
 
     @Headers("Content-Type: application/json")
-    @POST("/messages/{channel}") //serverの構造依存
-    fun sendMessage(@Path("channel") channel: Int, @Body message: Message): Observable<Message>
+    @POST("/messages") //serverの構造依存
+    fun sendMessage(@Body message: Message): Observable<Message>
 
-  
+    @Headers("Content-Type: application/json")
+    @POST("/messages/{id}")
+    fun getMessage(@Path("id") id: Int): Observable<Message>
+
+
     @Headers("Content-type: application/json")
-    @POST("/friendships/")
+    @POST("/friendships")
     fun sendPIN(@Body pin: Int): Observable<String>
 
     @PUT("/friendships/{person}")
@@ -64,7 +68,7 @@ interface Client {
 
 
     @Headers("Content-Type: application/json")
-    @POST("/channels/") //serverの構造依存
+    @POST("/channels") //serverの構造依存
     fun makeGroup(@Body group: Group): Observable<Group>
 
     @Headers("Content-Type: application/json")
@@ -76,10 +80,10 @@ interface Client {
     fun leaveGroup(@Path("channel") channel: Int, @Path("person") person: String): Observable<Group>
 
     @Headers("Content-Type: application/json")
-    @POST("/channels/{channel}/")
+    @POST("/channels/{channel}")
     fun inviteMultiplePerson(@Path("channel") channel: Int, @Body people: List<String>): Observable<Group>
-  
-  
+
+
     @Headers("Content-Type: application/json")
     @GET("/people/{uid}")
     fun getPerson(@Path("uid") uid: String): Observable<Member>

--- a/app/src/main/java/com/tokyoc/line_client/Client.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Client.kt
@@ -52,7 +52,7 @@ interface Client {
     fun sendMessage(@Body message: Message): Observable<Message>
 
     @Headers("Content-Type: application/json")
-    @POST("/messages/{id}")
+    @GET("/messages/{id}")
     fun getMessage(@Path("id") id: Int): Observable<Message>
 
 

--- a/app/src/main/java/com/tokyoc/line_client/MessageActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MessageActivity.kt
@@ -124,13 +124,14 @@ class MessageActivity : RxAppCompatActivity() {
 
             //通信部分の準備
             val message: Message = Message()
+            message.channel = groupId
             message.content = messageEditText.text.toString()
             messageEditText.setText("", TextView.BufferType.NORMAL)
 
             //ここから通信部分！
             Log.d("COMM", Client.gson.toJson(message))
 
-            client.sendMessage(groupId, message)
+            client.sendMessage(message)
                     .subscribeOn(Schedulers.io())
                     .observeOn(AndroidSchedulers.mainThread())
                     .subscribe({

--- a/app/src/main/java/com/tokyoc/line_client/Status.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Status.kt
@@ -1,8 +1,6 @@
 package com.tokyoc.line_client
 
 //StatusデータFormat
-//StatusデータFormat
 open class Status(
-    open var id: Int = 0,
-    open var friendshipCount: Int = 0,
-    open var latests: HashMap<Int, Int>)
+        open var friendshipCount: Int = 0,
+        open var latests: List<Summary>)

--- a/app/src/main/java/com/tokyoc/line_client/Summary.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Summary.kt
@@ -1,0 +1,6 @@
+package com.tokyoc.line_client
+
+open class Summary(
+        open var channelId: Int,
+        open var channelName: String,
+        open var messageId: Int)


### PR DESCRIPTION
ポーリングを実装しようと思ったらAPIを整理したくなったので、サーバー側の変更にあわせてクライアントも修正。 (cf. [Extend status #28](https://github.com/line-school2018summer/tokyo-c-server/pull/28))