### PR TITLE
画像の登録・取得・表示

### DIFF
--- a/app/src/main/java/com/tokyoc/line_client/ChangeImageActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/ChangeImageActivity.kt
@@ -20,6 +20,8 @@ import retrofit2.adapter.rxjava.HttpException
 import java.io.ByteArrayOutputStream
 import android.graphics.drawable.BitmapDrawable
 import com.google.firebase.storage.StorageMetadata
+import io.realm.Realm
+import io.realm.kotlin.where
 
 
 class ChangeImageActivity : AppCompatActivity() {
@@ -31,11 +33,15 @@ class ChangeImageActivity : AppCompatActivity() {
     var uri: Uri? = null
     var ba: ByteArray? = null
 
+    private lateinit var realm: Realm
+
     override fun onCreate(saveInstanceState: Bundle?) {
         super.onCreate(saveInstanceState)
         setContentView(R.layout.activity_image_change)
 
         val token = intent.getStringExtra("token")
+
+        realm = Realm.getDefaultInstance()
 
         findViewById<Button>(R.id.get_image_button).setOnClickListener() {
             val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
@@ -71,6 +77,10 @@ class ChangeImageActivity : AppCompatActivity() {
                                     firebaseUser?.updateProfile(profileUpdates)
                                             ?.addOnCompleteListener {
                                                 Log.d("COMM", "update success")
+                                                val self: Member? = realm.where<Member>().equalTo("isFriend", Relation.SELF).findFirst()
+                                                realm.executeTransaction {
+                                                    self?.photo = downloadUrl.toString()
+                                                }
                                                 val intent = Intent(this, ProfileActivity::class.java)
                                                 intent.putExtra("token", token)
                                                 startActivity(intent)

--- a/app/src/main/java/com/tokyoc/line_client/ChangeNameActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/ChangeNameActivity.kt
@@ -43,7 +43,9 @@ class ChangeNameActivity : AppCompatActivity() {
             firebaseUser?.updateProfile(profileUpdates)
                     ?.addOnCompleteListener {
                         Log.d("COMM", "update success")
-                        self?.name = newName
+                        realm.executeTransaction {
+                            self?.name = newName
+                        }
                         val intent = Intent(this, ProfileActivity::class.java)
                         intent.putExtra("token", token)
                         startActivity(intent)

--- a/app/src/main/java/com/tokyoc/line_client/Client.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Client.kt
@@ -48,7 +48,7 @@ interface Client {
     fun getMessages(@Query("channel") channel: Int, @Query("since_id") since_id: Int = 0): Observable<ResponseBody>
 
     @Headers("Content-Type: application/json")
-    @POST("/messages") //serverの構造依存
+    @POST("/messages")
     fun sendMessage(@Body message: Message): Observable<Message>
 
     @Headers("Content-Type: application/json")
@@ -68,7 +68,7 @@ interface Client {
 
 
     @Headers("Content-Type: application/json")
-    @POST("/channels") //serverの構造依存
+    @POST("/channels")
     fun makeGroup(@Body group: Group): Observable<Group>
 
     @Headers("Content-Type: application/json")

--- a/app/src/main/java/com/tokyoc/line_client/MakeGroupActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MakeGroupActivity.kt
@@ -42,9 +42,13 @@ class MakeGroupActivity: RxAppCompatActivity() {
                     .subscribe({
                         Log.d("COMM", "post done: name is ${it.name}, id is ${it.id}")
                         val groupId = it.id
+                        val self = realm.where<Member>().equalTo("isFriend", Relation.SELF).findFirst()
                         realm.executeTransaction {
                             val group = realm.createObject<Group>(groupId)
                             group.name = groupName
+                            if (self != null) {
+                                group.members.add(self.id)
+                            }
                         }
                         val intent = Intent(this, GroupActivity::class.java)
                         intent.putExtra("token", token)

--- a/app/src/main/java/com/tokyoc/line_client/MakePinActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MakePinActivity.kt
@@ -71,7 +71,9 @@ class MakePinActivity : RxAppCompatActivity() {
                                                             .observeOn(AndroidSchedulers.mainThread())
                                                             .subscribe({
                                                                 Log.d("COMM", "make friends succeeded: ${it.size}")
-                                                                member.isFriend = Relation.FRIEND
+                                                                realm.executeTransaction {
+                                                                    member.isFriend = Relation.FRIEND
+                                                                }
                                                             }, {
                                                                 Log.d("COMM", "make friends failed: ${it}")
                                                             })

--- a/app/src/main/java/com/tokyoc/line_client/MakePinActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MakePinActivity.kt
@@ -56,7 +56,7 @@ class MakePinActivity : RxAppCompatActivity() {
                                 pin_show.text = it.pin.toString()
                             } else if (it.type == "request") {
                                 val uid: String = it.person
-                                Member.lookup(uid, client)
+                                Member.lookup(uid, client, realm)
                                         .subscribeOn(Schedulers.io())
                                         .observeOn(AndroidSchedulers.mainThread())
                                         .subscribe({
@@ -77,7 +77,7 @@ class MakePinActivity : RxAppCompatActivity() {
                                                             })
                                                 })
                                                 setNegativeButton("Cancel", DialogInterface.OnClickListener { _, _ ->
-                                                    it.deregister()
+                                                    it.deregister(realm)
                                                 })
                                                 show()
                                             }

--- a/app/src/main/java/com/tokyoc/line_client/Member.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Member.kt
@@ -15,7 +15,6 @@ open class Member : RealmObject() {
     companion object {
         fun lookup(uid: String, client: Client, realm: Realm): rx.Observable<Member> {
             return rx.Observable.create<Member> {
-                val realm = Realm.getDefaultInstance()
                 val subscriber = it
 
                 realm.executeTransaction {

--- a/app/src/main/java/com/tokyoc/line_client/Member.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Member.kt
@@ -85,9 +85,6 @@ open class Member : RealmObject() {
     @SerializedName("DisplayName")
     open var name: String = "Aさん"
 
-    @SerializedName("PhotoURL")
-    open var photo: String = ""
-
     open var cached: Date = Date(0)
 
     open var isFriend: Int = Relation.OTHER

--- a/app/src/main/java/com/tokyoc/line_client/Member.kt
+++ b/app/src/main/java/com/tokyoc/line_client/Member.kt
@@ -13,7 +13,7 @@ import java.util.*
 //MemberデータFormat
 open class Member : RealmObject() {
     companion object {
-        fun lookup(uid: String, client: Client): rx.Observable<Member> {
+        fun lookup(uid: String, client: Client, realm: Realm): rx.Observable<Member> {
             return rx.Observable.create<Member> {
                 val realm = Realm.getDefaultInstance()
                 val subscriber = it
@@ -40,7 +40,7 @@ open class Member : RealmObject() {
         }
     }
 
-    fun deregister() {
+    fun deregister(realm: Realm) {
         if (this.isFriend == Relation.OTHER && this.groupJoin <= 0) {
             realm.executeTransaction {
                 this.deleteFromRealm()

--- a/app/src/main/java/com/tokyoc/line_client/MemberAdapter.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MemberAdapter.kt
@@ -1,10 +1,12 @@
 package com.tokyoc.line_client
 
+import android.graphics.BitmapFactory
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import com.bumptech.glide.Glide
 import io.realm.OrderedRealmCollection
 import io.realm.RealmBaseAdapter
 
@@ -35,7 +37,10 @@ class MemberListAdapter(data: OrderedRealmCollection<Member>) : RealmBaseAdapter
         adapterData?.run {
             val member = get(position)
             viewHolder.username.text = member.name
-            viewHolder.userImage.setImageResource(R.drawable.img001)
+            if (member.image.size > 0) {
+                viewHolder.userImage
+                        .setImageBitmap(BitmapFactory.decodeByteArray(member.image, 0, member.image.size))
+            }
         }
         return view
     }

--- a/app/src/main/java/com/tokyoc/line_client/MessageAdapter.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MessageAdapter.kt
@@ -1,19 +1,26 @@
 package com.tokyoc.line_client
 
+import android.graphics.BitmapFactory
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
+import com.tokyoc.line_client.R.drawable.img001
 import io.realm.OrderedRealmCollection
+import io.realm.Realm
 import io.realm.RealmBaseAdapter
+import io.realm.kotlin.where
 
 class MessageListAdapter(data: OrderedRealmCollection<Message>) : RealmBaseAdapter<Message>(data) {
+    private  var realm: Realm = Realm.getDefaultInstance()
 
     var messages0: MutableList<Message> = data
 
     inner class ViewHolder(cell: View) {
-        val messagecontent = cell.findViewById<TextView>(R.id.message_text_view)
+        val messageContent = cell.findViewById<TextView>(R.id.message_text_view)
         val messageAuthor = cell.findViewById<TextView>(R.id.author_name_text_view)
+        val messageImage = cell.findViewById<ImageView>(R.id.author_profile_image_view)
     }
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
@@ -35,8 +42,13 @@ class MessageListAdapter(data: OrderedRealmCollection<Message>) : RealmBaseAdapt
 
         adapterData?.run {
             val message = get(position)
-            viewHolder.messagecontent.text = message.content
-            viewHolder.messageAuthor.text = "誰かさん"
+            val author = realm.where<Member>().equalTo("id", message.author).findFirst()
+            viewHolder.messageContent.text = message.content
+            viewHolder.messageAuthor.text = author?.name ?: "取得失敗"
+            if (author != null && author.image.size > 0) {
+                viewHolder.messageImage
+                        .setImageBitmap(BitmapFactory.decodeByteArray(author.image, 0, author.image.size))
+            }
         }
         return view
     }

--- a/app/src/main/java/com/tokyoc/line_client/ProfileActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/ProfileActivity.kt
@@ -39,13 +39,12 @@ class ProfileActivity : AppCompatActivity() {
         }
 
         val photo = findViewById<ImageView>(R.id.photo_view)
-        //val uid = firebaseUser?.uid ?: "yoda"
-        val uid = "adafdas"
 
-        val imageRef = storageRef.child("images/${uid}.jpg")
+        val uri = self?.photo ?: "https://firebasestorage.googleapis.com/v0/b/tokyo-c-client.appspot.com/o/a.jpg?alt=media&token=8534f22a-d164-40fa-8cd1-1d3e6b5a494c"
+        Log.d("COMM", "uri: ${uri}")
+
         Glide.with(this)
-                .using<StorageReference>(FirebaseImageLoader())
-                .load(imageRef)
+                .load(uri)
                 .fitCenter()
                 .into(photo)
 

--- a/app/src/main/java/com/tokyoc/line_client/ProfileActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/ProfileActivity.kt
@@ -1,6 +1,7 @@
 package com.tokyoc.line_client
 
 import android.content.Intent
+import android.graphics.BitmapFactory
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
@@ -38,16 +39,10 @@ class ProfileActivity : AppCompatActivity() {
             startActivity(intent)
         }
 
-        val photo = findViewById<ImageView>(R.id.photo_view)
-
-        val uri = self?.photo ?: "https://firebasestorage.googleapis.com/v0/b/tokyo-c-client.appspot.com/o/a.jpg?alt=media&token=8534f22a-d164-40fa-8cd1-1d3e6b5a494c"
-        Log.d("COMM", "uri: ${uri}")
-
-        Glide.with(this)
-                .load(uri)
-                .fitCenter()
-                .into(photo)
-
+        if (self != null && self.image.size > 0) {
+            findViewById<ImageView>(R.id.photo_view)
+                    .setImageBitmap(BitmapFactory.decodeByteArray(self.image, 0, self.image.size))
+        }
 
         findViewById<Button>(R.id.change_image_button).setOnClickListener() {
             val intent = Intent(this, ChangeImageActivity::class.java)

--- a/app/src/main/java/com/tokyoc/line_client/SigninActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/SigninActivity.kt
@@ -67,7 +67,7 @@ class SigninActivity : AppCompatActivity() {
                                 val self: Member = realm.createObject<Member>(user.uid)
                                 self.name = user?.displayName ?: "default"
                                 self.isFriend = Relation.SELF
-                                self.photo = "https://firebasestorage.googleapis.com/v0/b/tokyo-c-client.appspot.com/o/a.jpg?alt=media&token=8534f22a-d164-40fa-8cd1-1d3e6b5a494c"
+                                self.updateImage()
                             }
                         }
                         val intent = Intent(this, GroupActivity::class.java)

--- a/app/src/main/java/com/tokyoc/line_client/SignupActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/SignupActivity.kt
@@ -83,7 +83,7 @@ class SignupActivity : AppCompatActivity() {
                                 val self: Member = realm.createObject<Member>(user.uid)
                                 self.name = name
                                 self.isFriend = Relation.SELF
-                                self.photo = "https://firebasestorage.googleapis.com/v0/b/tokyo-c-client.appspot.com/o/images%2Fyoda.jpg?alt=media&token=07092dc3-6ead-432f-94d5-a840be1a9fac"
+                                self.updateImage()
                             }
                             val intent = Intent(this, GroupActivity::class.java)
                             intent.putExtra("token", token)


### PR DESCRIPTION
メンバーのプロフィール画像を扱えるようになりました。
コミットごとに変更を見ると、途中でちょっと迷走しているんで、多分全部の変更をまとめてみてもらった方がいいです。

自分の画像をrealmに登録するトリガが、
realmを全部消すような行為（サインアップするか同じエミュレータで別の人間がサインイン）と
手動での登録（エミュレータの中に画像をダウンロードしてからやって下さい）しかないので、
これをやってもらえるとありがたいです。
（これをしなくてもバグったりはしないようにしたつもりやけど、こういう場合は本来想定外なのであまり真面目に試していない）