### PR TITLE
バグとり

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,5 +25,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -25,5 +25,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/app/src/main/java/com/tokyoc/line_client/GroupActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/GroupActivity.kt
@@ -127,7 +127,7 @@ class GroupActivity : AppCompatActivity() {
 
         val member1 = realm.where<Member>().findAll()
         for (i in member1) {
-            Log.d("COMM", "${i.isFriend}, ${i.name}")
+            Log.d("COMM", "group activity: ${i.isFriend}, ${i.name}")
         }
     }
 

--- a/app/src/main/java/com/tokyoc/line_client/MemberProfileActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MemberProfileActivity.kt
@@ -20,25 +20,26 @@ import io.realm.Realm
 import io.realm.kotlin.where
 
 
-class ProfileActivity : AppCompatActivity() {
+class MemberProfileActivity : AppCompatActivity() {
     private lateinit var realm: Realm
 
     override fun onCreate(saveInstanceState: Bundle?) {
         super.onCreate(saveInstanceState)
-        setContentView(R.layout.activity_profile)
+        setContentView(R.layout.activity_profile_member)
 
         val token = intent.getStringExtra("token")
+        val memberId = intent.getStringExtra("memberId")
         val toolbar = supportActionBar!!
         toolbar.setDisplayHomeAsUpEnabled(true)
 
         realm = Realm.getDefaultInstance()
-        val self = realm.where<Member>().equalTo("isFriend", Relation.SELF).findFirst()
-        Log.d("CHECK", "$self , ${self?.name}")
-        findViewById<TextView>(R.id.name_view).text = self?.name ?: "取得失敗"
+        val member = realm.where<Member>().equalTo("id", memberId).findFirst()
+        Log.d("CHECK", "$member , ${member?.name}")
+        findViewById<TextView>(R.id.name_view).text = member?.name ?: "取得失敗"
 
-        if (self != null && self.image.size > 0) {
+        if (member != null && member.image.size > 0) {
             findViewById<ImageView>(R.id.photo_view)
-                    .setImageBitmap(BitmapFactory.decodeByteArray(self.image, 0, self.image.size))
+                    .setImageBitmap(BitmapFactory.decodeByteArray(member.image, 0, member.image.size))
         }
     }
 

--- a/app/src/main/java/com/tokyoc/line_client/MessageActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/MessageActivity.kt
@@ -96,15 +96,12 @@ class MessageActivity : RxAppCompatActivity() {
                                                 val realm = Realm.getDefaultInstance()
                                                 val memberCome = it
                                                 val group = realm.where<Group>().equalTo("id", groupId).findFirst()
-                                                Log.d("COMM", "zero okay")
                                                 realm.executeTransaction {
                                                     group?.members?.add(author)
-                                                    Log.d("COMM", "one okay")
                                                     if (memberCome != null) {
                                                         memberCome.groupJoin += 1
                                                         realm.insertOrUpdate(memberCome)
                                                     }
-                                                    Log.d("COMM", "two okay")
                                                 }
                                                 Log.d("COMM", "now ${group?.members?.size} members")
                                             }, {

--- a/app/src/main/java/com/tokyoc/line_client/PollingService.kt
+++ b/app/src/main/java/com/tokyoc/line_client/PollingService.kt
@@ -41,10 +41,13 @@ class PollingService : IntentService("polling_service") {
                         .flatMap { return@flatMap Member.lookup(it, client) }
                         .subscribe {
                             val member = it
+                            Log.d("DDDDD", "got it ! ${member.name}, ${member.isFriend}")
 
-                            if (member.isFriend == Relation.FRIEND) {
+                            if (member.isFriend != Relation.OTHER) {
                                 return@subscribe
                             }
+
+                            Log.d("DDDDD", "it'll be friend ${member.name}, ${member.isFriend}")
 
                             member.isFriend = Relation.FRIEND
 
@@ -65,8 +68,10 @@ class PollingService : IntentService("polling_service") {
                         .not().beginGroup().`in`("id", friends).endGroup()
                         .findAll().forEach {
                             val member = it
+                            Log.d("DDDD", "it'll be other ${member.name}, ${member.isFriend}")
 
                             if (member.isFriend == Relation.FRIEND) {
+                                Log.d("DDDD", "good bye ${member.name}, ${member.isFriend}")
                                 realm.executeTransaction { member.isFriend = Relation.OTHER }
                             }
                         }

--- a/app/src/main/java/com/tokyoc/line_client/SettingActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/SettingActivity.kt
@@ -84,12 +84,16 @@ class SettingActivity : AppCompatActivity() {
         //サインアウトボタンを押した時の処理
         findViewById<ImageButton>(R.id.signout_button).setOnClickListener {
             val intent = Intent(this, SigninActivity::class.java)
+            val service = Intent(this, PollingService::class.java)
             AlertDialog.Builder(this).apply {
                 setTitle("Sign Out")
                 setMessage("Really Sign Out?")
                 setPositiveButton("OK", DialogInterface.OnClickListener { _, _ ->
                     FirebaseAuth.getInstance().signOut()
                     startActivity(intent)
+                    service.putExtra("token", token)
+                    stopService(service)
+                    Log.d("DDDD", "stop")
                 })
                 setNegativeButton("Cancel", null)
                 show()
@@ -105,7 +109,7 @@ class SettingActivity : AppCompatActivity() {
 
         val member1 = realm.where<Member>().findAll()
         for (i in member1) {
-            Log.d("COMM", "${i.isFriend}, ${i.name}")
+            Log.d("COMM", "setting activity: ${i.isFriend}, ${i.name}")
         }
     }
 

--- a/app/src/main/java/com/tokyoc/line_client/SigninActivity.kt
+++ b/app/src/main/java/com/tokyoc/line_client/SigninActivity.kt
@@ -61,21 +61,21 @@ class SigninActivity : AppCompatActivity() {
                     val user = firebase.currentUser
                     Log.d("COMM", "a")
                     if (user != null) {
-                        realm = Realm.getDefaultInstance()
+                        val realm = Realm.getDefaultInstance()
                         val self = realm.where<Member>().equalTo("isFriend", Relation.SELF).findFirst()
                         if (self?.id != user.uid) {
                             realm.executeTransaction {
                                 realm.deleteAll()
-                                val self: Member = realm.createObject<Member>(user.uid)
-                                self.name = user?.displayName ?: "default"
-                                self.isFriend = Relation.SELF
-                                self.updateImage()
-                                Log.d("COMM", "missify")
+                                val selfNew: Member = realm.createObject<Member>(user.uid)
+                                selfNew.name = user.displayName ?: "default"
+                                selfNew.isFriend = Relation.SELF
+                                selfNew.updateImage()
+                                Log.d("COMM", "new self updated")
                             }
                         }
                         val member1 = realm.where<Member>().findAll()
                         for (i in member1) {
-                            Log.d("COMM", "${i.isFriend}, ${i.name}")
+                            Log.d("COMM", "sign in: ${i.isFriend}, ${i.name}")
                         }
                         val intent = Intent(this, GroupActivity::class.java)
                         intent.putExtra("token", token)

--- a/app/src/main/res/layout/activity_profile_member.xml
+++ b/app/src/main/res/layout/activity_profile_member.xml
@@ -21,4 +21,9 @@
         android:textSize="32dp"
         android:text="取得中" />
 
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="個人トーク開始"/>
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_profile_member.xml
+++ b/app/src/main/res/layout/activity_profile_member.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_horizontal"
+    android:orientation="vertical">
+
+    <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/photo_view"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        android:layout_marginTop="100dp"
+        android:layout_marginBottom="50dp"
+        android:src="@drawable/img001"/>
+
+    <TextView
+        android:id = "@+id/name_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="32dp"
+        android:text="取得中" />
+
+</LinearLayout>


### PR DESCRIPTION
MemberProfileActivityとかの新しいファイルが作られていますが、いったん気にしないでください。存在しているだけです。

今回、以下2点のバグを除きました（少なくとも僕の手元では何度も試して今のところ起こらなくなっています）。
・自分自身が知らぬ間に他人になっている
・なんか何もしていないときに突然通知が来る

以下、詳しいバグの原因の説明です。暇なら読んでください。

この2つの原因となっていたのはMember.lookupの中です。
cacheをclient.getPersonの返り値として新たに定義したことにより、ここで強制的にisFriendが2になっています。これにより何が起こるかというと、PollingActivityにおいて
・新しいメッセージが来たとき、そのauthorをMember.lookupに渡しているので、「自分自身からのメッセージを受信した瞬間に自分自身が他人になる」という現象が起きる。
・友達情報の更新時刻となる5分を過ぎたとき、PollingActivityから呼んだMember.lookupの中でそいつのisFriendをRelation.OTHERにしたあとで、呼び出し元のPollingActivityでもう一度isFriendをRelation.FRIENDにしている。これによって「友達になったよ～」って通知が来る。